### PR TITLE
Make infra/python compatible with both Python 2 & 3

### DIFF
--- a/infra/python/bootstrap_virtualenv.py
+++ b/infra/python/bootstrap_virtualenv.py
@@ -239,7 +239,7 @@ def install_compiled_deps_if_possible():
   # problem with inline declarations in older libc headers. Setting -fgnu89-inline is a
   # workaround.
   distro_version = ''.join(exec_cmd(["lsb_release", "-irs"]).lower().split())
-  print distro_version
+  print(distro_version)
   if distro_version.startswith("centos5."):
     env["CFLAGS"] = "-fgnu89-inline"
 
@@ -381,8 +381,8 @@ if __name__ == "__main__":
 
   if options.print_ld_library_path:
     kudu_client_dir = find_kudu_client_install_dir()
-    print os.path.pathsep.join([os.path.join(kudu_client_dir, 'lib'),
-                                os.path.join(kudu_client_dir, 'lib64')])
+    print(os.path.pathsep.join([os.path.join(kudu_client_dir, 'lib'),
+                                    os.path.join(kudu_client_dir, 'lib64')]))
     sys.exit()
 
   logging.basicConfig(level=getattr(logging, options.log_level))

--- a/infra/python/deps/find_py26.py
+++ b/infra/python/deps/find_py26.py
@@ -42,4 +42,4 @@ def detect_python_cmd():
         return cmd_path
   raise Exception("Could not find minimum required python version 2.6")
 
-print detect_python_cmd()
+print(detect_python_cmd())

--- a/infra/python/deps/pip_download.py
+++ b/infra/python/deps/pip_download.py
@@ -29,7 +29,10 @@ import re
 import sys
 from random import randint
 from time import sleep
-from urllib import urlopen, FancyURLopener
+try:
+  from urllib import urlopen, FancyURLopener
+except ImportError:
+  from urllib.request import urlopen, FancyURLopener
 
 NUM_DOWNLOAD_ATTEMPTS = 8
 
@@ -48,7 +51,7 @@ def check_digest(filename, algorithm, expected_digest):
     # Fallback to hardcoded set if hashlib.algorithms_available doesn't exist.
     supported_algorithms = set(['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'])
   if algorithm not in supported_algorithms:
-    print 'Hash algorithm {0} is not supported by hashlib'.format(algorithm)
+    print('Hash algorithm {0} is not supported by hashlib'.format(algorithm))
     return False
   h = hashlib.new(algorithm)
   h.update(open(filename).read())
@@ -60,18 +63,18 @@ def retry(func):
   '''Retry decorator.'''
 
   def wrapper(*args, **kwargs):
-    for try_num in xrange(NUM_DOWNLOAD_ATTEMPTS):
+    for try_num in range(NUM_DOWNLOAD_ATTEMPTS):
       if try_num > 0:
         sleep_len = randint(5, 10 * 2 ** try_num)
-        print 'Sleeping for {0} seconds before retrying'.format(sleep_len)
+        print('Sleeping for {0} seconds before retrying'.format(sleep_len))
         sleep(sleep_len)
       try:
         result = func(*args, **kwargs)
         if result:
           return result
       except Exception as e:
-        print e
-    print 'Download failed after several attempts.'
+        print(e)
+    print('Download failed after several attempts.')
     sys.exit(1)
 
   return wrapper
@@ -83,7 +86,7 @@ def get_package_info(pkg_name, pkg_version):
   # same result is always returned even if the ordering changed on the server.
   candidates = []
   url = '{0}/simple/{1}/'.format(PYPI_MIRROR, pkg_name)
-  print 'Getting package info from {0}'.format(url)
+  print('Getting package info from {0}'.format(url))
   # The web page should be in PEP 503 format (https://www.python.org/dev/peps/pep-0503/).
   # We parse the page with regex instead of an html parser because that requires
   # downloading an extra package before running this script. Since the HTML is guaranteed
@@ -101,7 +104,7 @@ def get_package_info(pkg_name, pkg_version):
         file_name.endswith('-{0}.zip'.format(pkg_version))):
       candidates.append((file_name, path, hash_algorithm, digest))
   if not candidates:
-    print 'Could not find archive to download for {0} {1}'.format(pkg_name, pkg_version)
+    print('Could not find archive to download for {0} {1}'.format(pkg_name, pkg_version))
     return (None, None, None, None)
   return sorted(candidates)[0]
 
@@ -113,16 +116,16 @@ def download_package(pkg_name, pkg_version):
     return False
   if os.path.isfile(file_name) and check_digest(file_name, hash_algorithm,
       expected_digest):
-    print 'File with matching digest already exists, skipping {0}'.format(file_name)
+    print('File with matching digest already exists, skipping {0}'.format(file_name))
     return True
   downloader = FancyURLopener()
   pkg_url = '{0}/packages/{1}'.format(PYPI_MIRROR, path)
-  print 'Downloading {0} from {1}'.format(file_name, pkg_url)
+  print('Downloading {0} from {1}'.format(file_name, pkg_url))
   downloader.retrieve(pkg_url, file_name)
   if check_digest(file_name, hash_algorithm, expected_digest):
     return True
   else:
-    print 'Hash digest check failed in file {0}.'.format(file_name)
+    print('Hash digest check failed in file {0}.'.format(file_name))
     return False
 
 def main():


### PR DESCRIPTION
While trying to build Impala from [this guide](https://cwiki.apache.org/confluence/display/IMPALA/Building+Impala) I had to make the following changes to make the involved scripts Python3 compatible.

I am not sure if there is any other Python code in the project so I have kept this code compatible with both Python 2 & 3 (as I reckon that you only support Python 2 right now).
But this code can be merged as it will not break for any current Python 2 maintainers AND will also be helpful for developers like me who have shifted to Python3.

[Support for Python 2 is going to be dropped after 1st Jan 2020 according to current announcements.](https://pythonclock.org)