### PR TITLE
IMPALA-10721: MetastoreServiceHandler should extend AbstractThriftHiveMetastore

### DIFF
--- a/fe/src/main/java/org/apache/impala/catalog/metastore/MetastoreServiceHandler.java
+++ b/fe/src/main/java/org/apache/impala/catalog/metastore/MetastoreServiceHandler.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
+import org.apache.hadoop.hive.metastore.AbstractThriftHiveMetastore;
 import org.apache.hadoop.hive.metastore.DefaultPartitionExpressionProxy;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.PartFilterExprUtil;
@@ -279,7 +280,7 @@ import org.slf4j.LoggerFactory;
  * the arguments before sending the RPC to the HMS server. This can lead to unexpected
  * side-effects like (processorCapabilities do not match with the actual client).
  */
-public abstract class MetastoreServiceHandler implements Iface {
+public abstract class MetastoreServiceHandler extends AbstractThriftHiveMetastore {
 
   private static final Logger LOG = LoggerFactory
       .getLogger(MetastoreServiceHandler.class);


### PR DESCRIPTION
MetastoreServiceHandler should extend AbstractThriftHiveMetastore
which has default implementation of all the HMS APIs.
This avoids broken builds in Impala, whenever it
dynamically picks Hive GBN, which might have new HMS APIs.
