### PR TITLE
cleaner and faster operations wtih datasketches

### DIFF
--- a/be/src/exprs/datasketches-common.h
+++ b/be/src/exprs/datasketches-common.h
@@ -50,16 +50,7 @@ const int DS_CPC_SKETCH_CONFIG = 11;
 const int DS_DEFAULT_KAPPA = 2;
 
 /// Logs a common error message saying that sketch deserialization failed.
-void LogSketchDeserializationError(FunctionContext* ctx);
-
-/// Receives a serialized DataSketches sketch (either Hll or KLL) in
-/// 'serialized_sketch', deserializes it and puts the deserialized sketch into 'sketch'.
-/// The outgoing 'sketch' will hold the same configs as 'serialized_sketch' regardless of
-/// what was provided when it was constructed before this function call. Returns false if
-/// the deserialization fails, true otherwise.
-template<class T>
-bool DeserializeDsSketch(const StringVal& serialized_sketch, T* sketch)
-    WARN_UNUSED_RESULT;
+void LogSketchDeserializationError(FunctionContext* ctx, const std::exception& e);
 
 /// Helper function that receives an std::stringstream and converts it to StringVal. Uses
 /// 'ctx' for memory allocation.


### PR DESCRIPTION
I believe these changes should result in cleaner code and more efficient operations with datasketches. I would love to compare performance before and after, but I am not sure how to approach this at the moment since I have no experience with Impala yet.
I also added messages from original exceptions to re-thrown exceptions.