### PR TITLE
IMPALA-11612: fix ORDER BY expression rewrite bug

### DIFF
--- a/fe/src/main/java/org/apache/impala/analysis/SelectStmt.java
+++ b/fe/src/main/java/org/apache/impala/analysis/SelectStmt.java
@@ -1398,7 +1398,9 @@ public class SelectStmt extends QueryStmt {
     }
     if (orderByElements_ != null) {
       for (OrderByElement orderByElem: orderByElements_) {
-        orderByElem.setExpr(rewriteCheckOrdinalResult(rewriter, orderByElem.getExpr()));
+        Expr orderByExpr = resolveReferenceExpr(orderByElem.getExpr(), "ORDER BY",
+                analyzer_, true);
+        orderByElem.setExpr(rewriteCheckOrdinalResult(rewriter, orderByExpr));
       }
     }
   }

--- a/fe/src/test/java/org/apache/impala/analysis/ExprRewriterTest.java
+++ b/fe/src/test/java/org/apache/impala/analysis/ExprRewriterTest.java
@@ -384,6 +384,23 @@ public class ExprRewriterTest extends AnalyzerTest {
             + "FROM functional.alltypes WHERE "
             + "bool_col OR id = 2 OR concat(string_col, 'test') = 'testtest'");
 
+    assertToSql(ctx,
+        "select (case when (1 = 1 and `t1`.`dt` = '2022-05-13') then '2022-05-13' end) d0\n"
+            + "from `jhk_test`.`p1` `t1`\n"
+            + "group by (case when (1 = 1 and `t1`.`dt` = '2022-05-13') then '2022-05-13' end)\n"
+            + "order by (case when (1 = 1 and `t1`.`dt` = '2022-05-13') then '2022-05-13' end)\n"
+            + "limit 10",
+        "SELECT (CASE WHEN (1 = 1 AND `t1`.`dt` = '2022-05-13') THEN '2022-05-13' END) d0\n"
+            + "FROM `jhk_test`.`p1` `t1`\n"
+            + "GROUP BY (CASE WHEN (1 = 1 AND `t1`.`dt` = '2022-05-13') THEN '2022-05-13' END)\n"
+            + "ORDER BY (CASE WHEN (1 = 1 AND `t1`.`dt` = '2022-05-13') THEN '2022-05-13' END)\n"
+            + "LIMIT 10",
+            "SELECT (CASE WHEN (`t1`.`dt` = '2022-05-13') THEN '2022-05-13' END) d0\n"
+            + "FROM `jhk_test`.`p1` `t1`\n"
+            + "GROUP BY (CASE WHEN (`t1`.`dt` = '2022-05-13') THEN '2022-05-13' END)\n"
+            + "ORDER BY (CASE WHEN (`t1`.`dt` = '2022-05-13') THEN '2022-05-13' END)\n"
+            + "LIMIT 10");
+    
     // We don't do any rewrite for WITH clause.
     StatementBase stmt = (StatementBase) AnalyzesOk("with t as (select 1 + 1) " +
         "select id from functional.alltypes union select id from functional.alltypesagg",


### PR DESCRIPTION
When the query SQL is overwritten, both the selectList and groupByList fields are preprocessed except for the orderByList fields, so add preprocessing before the orderByList rewrite 