### PR TITLE
Add last_day to the heading

### DIFF
--- a/docs/topics/impala_datetime_functions.xml
+++ b/docs/topics/impala_datetime_functions.xml
@@ -173,6 +173,11 @@ under the License.
         <xref href="#datetime_functions/int_months_between"
           >INT_MONTHS_BETWEEN</xref>
       </li>
+      
+      <li>
+        <xref href="#datetime_functions/last_day"
+          >LAST_DAY</xref>
+      </li>
 
       <li>
         <xref href="#datetime_functions/microseconds_add"


### PR DESCRIPTION
Function last_day is present in the document, but is absent in the table of contents