### PR TITLE
[IMPALA-12291] - impala checks hdfs ranger policy

### DIFF
--- a/fe/src/main/java/org/apache/impala/catalog/HdfsTable.java
+++ b/fe/src/main/java/org/apache/impala/catalog/HdfsTable.java
@@ -38,6 +38,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
@@ -833,16 +835,23 @@ public class HdfsTable extends Table implements FeFsTable {
     Preconditions.checkNotNull(location);
     FileSystem fs = location.getFileSystem(CONF);
 
+    String hdfsAuthClass = CONF.get("dfs.namenode.inode.attributes.provider.class");
+    boolean hdfsRangerEnabled = false;
+
+    if (hdfsAuthClass != null && hdfsAuthClass.equals("org.apache.ranger.authorization.hadoop.RangerHdfsAuthorizer")) {
+      hdfsRangerEnabled = true;
+    }
+
     if (assumeReadWriteAccess(fs)) return TAccessLevel.READ_WRITE;
 
     while (location != null) {
       try {
         FsPermissionChecker.Permissions perms = permCache.getPermissions(location);
-        if (perms.canReadAndWrite()) {
+        if (hdfsRangerEnabled ? checkAccess(location, fs, FsAction.getFsAction("rw-")) : perms.canReadAndWrite()) {
           return TAccessLevel.READ_WRITE;
-        } else if (perms.canRead()) {
+        } else if (hdfsRangerEnabled ? checkAccess(location, fs, FsAction.getFsAction("r--")) : perms.canRead()) {
           return TAccessLevel.READ_ONLY;
-        } else if (perms.canWrite()) {
+        } else if (hdfsRangerEnabled ? checkAccess(location, fs, FsAction.getFsAction("-w-")) : perms.canWrite()) {
           return TAccessLevel.WRITE_ONLY;
         }
         return TAccessLevel.NONE;
@@ -3158,4 +3167,14 @@ public class HdfsTable extends Table implements FeFsTable {
     }
     return true;
   }
+
+  public static boolean checkAccess(Path path, FileSystem fs, FsAction action) throws IOException {
+    try {
+      fs.access(path, action);
+    } catch (AccessControlException e) {
+      return false;
+    }
+    return true;
+  }
+
 }

--- a/fe/src/main/java/org/apache/impala/service/Frontend.java
+++ b/fe/src/main/java/org/apache/impala/service/Frontend.java
@@ -2084,6 +2084,7 @@ public class Frontend {
           + planCtx.compilationState_.getAvailableCoresPerNode() + " cores per node.");
 
       String retryMsg = "";
+      String errorMsg = "";
       while (true) {
         try {
           req = doCreateExecRequest(planCtx, timeline);
@@ -2103,7 +2104,11 @@ public class Frontend {
           LOG.warn("Retrying plan of query {}: {} (retry #{} of {})",
               queryCtx.client_request.stmt, retryMsg, attempt,
               INCONSISTENT_METADATA_NUM_RETRIES);
-        }
+        } catch (AnalysisException e) {
+          errorMsg = e.getMessage();
+          LOG.warn("Analysis Exception query {}: {}",
+              queryCtx.client_request.stmt, errorMsg);
+          throw e;
       }
 
       // Counters about this group set.


### PR DESCRIPTION
### Related Issue
* https://issues.apache.org/jira/projects/IMPALA/issues/IMPALA-12291

### Description
* When HDFS is ranger enabled, current impala fe doesn't check ranger policy but hadoop inode permission
* New feature adds getAvailableAccessLevel() method ranger check code using Hadoop API
* Add one more catch in getTExecRequest() method to check AnalysisException

### Test
* Manual Test done
  * Distribute impala fe jar for impalad and catalogd
  * Enable HDFS Ranger Plugin.
  * Give impala Allow condition for ranger hdfs policy and check insert query - Insert Success
  * Give impala Deny condition for ranger hdfs policy and check insert query -  Insert Fail
