### PR TITLE
IMPALA-12399: Pass eventTypeSkipList with OPEN_TXN in NotificationEventRequest to avoid receiving OPEN_TXN events from hive metastore

### DIFF
--- a/fe/src/main/java/org/apache/impala/catalog/events/MetastoreEventsProcessor.java
+++ b/fe/src/main/java/org/apache/impala/catalog/events/MetastoreEventsProcessor.java
@@ -265,6 +265,9 @@ public class MetastoreEventsProcessor implements ExternalEventsProcessor {
 
   private static final long SECOND_IN_NANOS = 1000 * 1000 * 1000L;
 
+  // List of event types that can be skipped while fetching notification events from metastore
+  private static final List<String> eventSkipList = Arrays.asList("OPEN_TXN");
+
   /**
    * Wrapper around {@link
    * MetastoreEventsProcessor#getNextMetastoreEventsInBatches(CatalogServiceCatalog,
@@ -312,6 +315,7 @@ public class MetastoreEventsProcessor implements ExternalEventsProcessor {
         NotificationEventRequest eventRequest = new NotificationEventRequest();
         eventRequest.setMaxEvents(batchSize);
         eventRequest.setLastEvent(currentEventId);
+        eventRequest.setEventTypeSkipList(eventSkipList);
         NotificationEventResponse notificationEventResponse = MetastoreShim
             .getNextNotification(msc.getHiveClient(), eventRequest);
         for (NotificationEvent event : notificationEventResponse.getEvents()) {
@@ -819,6 +823,7 @@ public class MetastoreEventsProcessor implements ExternalEventsProcessor {
       NotificationEventRequest eventRequest = new NotificationEventRequest();
       eventRequest.setLastEvent(eventId);
       eventRequest.setMaxEvents(batchSize);
+      eventRequest.setEventTypeSkipList(eventSkipList);
       NotificationEventResponse response = MetastoreShim
           .getNextNotification(msClient.getHiveClient(), eventRequest);
       LOG.info(String.format("Received %d events. Start event id : %d",


### PR DESCRIPTION
Notification events like OPEN_TXN are ignored on catalogd MetastoreEventsProcessor. So, we can pass eventTypeSkipList with OPEN_TXN in NotificationEventRequest while invoking get_next_notification() to avoid reading such notification messages from metastore and then ignoring on catalogd. OPEN_TXN event being more frequent(received even upon describe table operation from beeline), we can significantly reduce unwanted processing on both hive metastore and catalogd. Catalogd reads events in batches of EVENTS_BATCH_SIZE_PER_RPC, skipping such unnecessary events can help catchup the events faster.

Testing:
 - Manually tested