### PR TITLE
[IMPALA-13112] Remove Kafka Dependency Exclusion to Use KafkaAuditProvider

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -176,10 +176,6 @@ under the License.
           <groupId>com.cloudera</groupId>
           <artifactId>jwtprovider-knox</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.apache.kafka</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
         <!-- After RANGER-3498, Ranger's ranger-plugins-audit starts pulling in
         log4j-1.2-api, which is banned by Impala's frontend. Thus we exclude the
         dependency here.-->


### PR DESCRIPTION
**Issue** : https://issues.apache.org/jira/browse/IMPALA-13112

**Testing Environment:**
The changes were tested in the following environment:
- Impala Version: 4.1.1
- Ranger Version: 2.3.0

**Results:**
The tests confirmed that with the Kafka dependency exclusion removed:

Impala started successfully without any java.lang.NoClassDefFoundError errors related to javax.ws.rs.
Ranger's Kafka-based audit logging functioned correctly with the Kafka client included.
This change is expected to improve the integration between Impala and Ranger by enabling Kafka-based audit logging without reintroducing previous conflicts.