### PR TITLE
IMPALA-14778: Guard IcebergMetadataScanNode::Close() against null met…

### DIFF
--- a/be/src/exec/iceberg-metadata/iceberg-metadata-scan-node.cc
+++ b/be/src/exec/iceberg-metadata/iceberg-metadata-scan-node.cc
@@ -120,7 +120,7 @@ Status IcebergMetadataScanNode::GetNext(RuntimeState* state, RowBatch* row_batch
 
 void IcebergMetadataScanNode::Close(RuntimeState* state) {
   if (is_closed()) return;
-  metadata_scanner_->Close(state);
+  if (metadata_scanner_) metadata_scanner_->Close(state);
   ScanNode::Close(state);
 }
 


### PR DESCRIPTION
Add a null check before invoking metadata_scanner_->Close(state) in IcebergMetadataScanNode::Close() to prevent potential dereference of a null pointer when the scanner is not initialized.