### PR TITLE
IMPALA-14955: Include libhdfs Java stack trace in HDFS error messages

### DIFF
--- a/be/src/util/hdfs-util.cc
+++ b/be/src/util/hdfs-util.cc
@@ -51,6 +51,10 @@ string GetHdfsErrorMsg(const string& prefix, const string& file) {
   if (root_cause != nullptr) {
     ss << "\nRoot cause: " << root_cause;
   }
+  char* stack_trace = hdfsGetLastExceptionStackTrace();
+  if (stack_trace != nullptr) {
+    ss << "\nStack trace:\n" << stack_trace;
+  }
   return ss.str();
 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IMPALA-14955

When an HDFS/libhdfs operation fails, Impala currently includes libhdfs root cause output in `GetHdfsErrorMsg()`. However, some failures, especially exceptions raised inside filesystem client code, need the full Java stack trace to identify the actual failing path.

This change appends `hdfsGetLastExceptionStackTrace()` to the HDFS error message when libhdfs provides one.

## Motivation

We hit an issue earlier when using Ozone (HCFS):

```
Failed to close HDFS file
Error(255): Unknown error 255
Root cause: ArrayIndexOutOfBoundsException
```

but the actual Java stack trace was not captured in the query/profile error. Including the libhdfs stack trace would be help immensely.